### PR TITLE
Fix social icons on dark theme. Fixes #78

### DIFF
--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -28,7 +28,8 @@ a:hover .feather-moon {
   color: white;
 }
 
-.social-icons-list .social-icon {
+.social-icons-list .social-icon,
+.social-icons-list .social-icon a:visited  {
   fill: var(--dark-text-color);
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -244,7 +244,6 @@ pre {
 
 code {
   box-decoration-break: clone;
-  padding: 0 3px;
   word-wrap: break-word;
   font-size: 0.8em;
 }


### PR DESCRIPTION
I updated the social icon links on the dark theme and removed the padding on the code blocks. I noticed the issue with the code blocks when showing multiple lines in a recent post.