### PR TITLE
Fix hover color flicker for visited social icons

### DIFF
--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -28,8 +28,7 @@ a:hover .feather-moon {
   color: white;
 }
 
-.social-icons-list .social-icon,
-.social-icons-list .social-icon a:visited  {
+.social-icons-list .social-icon {
   fill: var(--dark-text-color);
 }
 


### PR DESCRIPTION
Steps to reproduce the issue:
1. Open demo link
2. Make sure that the current theme is dark
3. Click on any social icon which will take you to example.com
4. Return back to Gokarna home page
5. Hover over social icons again
6. The icons color flickers between red and white (in dark theme)

