### PR TITLE
Fix homepage width and alignment of posts

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -418,7 +418,9 @@ table td {
 }
 
 .home-posts {
+  margin: auto;
   padding-top: 20px;
+  width: 80%;
 }
 
 /* SINGLE */


### PR DESCRIPTION
Just noticed that the homepage posts box was a little skewed in alignment and width. Also made sure it's still responsive

Before:

<img width="1440" alt="Screenshot 2022-05-30 at 10 50 48" src="https://user-images.githubusercontent.com/7583815/170955316-ca27dfe9-e89c-46d5-9ada-6262770289bc.png">

After:

<img width="1440" alt="Screenshot 2022-05-30 at 10 50 41" src="https://user-images.githubusercontent.com/7583815/170955351-8913dd27-d8d2-4bae-a231-c4f6f148b416.png">
