### PR TITLE
Add Feather icons to exampleSite menu

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -48,21 +48,25 @@ pygmentsStyle = "monokai"
 [menu]
   [[menu.main]]
     name = "Home"
+    pre = "<span data-feather='home'></span>"
     url = "/"
     weight = 1
 
   [[menu.main]]
     name = "Posts"
+    pre = "<span data-feather='book'></span>"
     url = "/posts/"
     weight = 2
 
   [[menu.main]]
     name = "Projects"
+    pre = "<span data-feather='code'></span>"
     url = "/projects/"
     weight = 3
 
   [[menu.main]]
     name = "Tags"
+    pre = "<span data-feather='tag'></span>"
     url = "/tags/"
     weight = 4
 


### PR DESCRIPTION
After seeing #107 , I thought that placing Feather icons in the menu would be another welcome addition.

I acknowledge that Gokarna is a minimal theme, but my rationale for submitting this PR is that there is a consistent use of icons - including the social icons and avatar - making the Home, Posts, Projects and Tags menu items stand out by their omission.

No offence taken if you decline this PR. Cheers!