### PR TITLE
Show popular posts on homepage

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -10,6 +10,7 @@ enableRobotsTXT = true
 pygmentsStyle = "monokai"
 
 [params]
+  showPostsOnHomePage = "popular"
   footer = "The Marauders"
   description = "Sky above, sand below and peace within"
   avatarURL = "/images/avatar.webp"


### PR DESCRIPTION
The `weight` attribute is defined in `exampleSite/posts/` files, but the parameter is not set in `config.toml`.

This PR adds popular posts to the homepage.

Please decline if unwanted.