### PR TITLE
Add a license header to the footer

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -44,6 +44,7 @@ pygmentsStyle = "monokai"
     {name = "email", url = "mailto:example@example.com"}
   ]
   metaKeywords = ["blog", "gokarna", "hugo"]
+  licenseHeader = "This code is licensed under [GNU GPLv3](https://www.gnu.org/licenses/gpl-3.0.html)"
 
 [menu]
   [[menu.main]]

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -223,11 +223,19 @@ Text to display in the footer section
 
 #### Display a license header
 
-If you copyright your content using the same license, write the header using Markdown.
+Apply a copyright license to all of your pages.
+
+Markdown is permitted, to add links for example:
 
 ```toml
 [params]
   licenseHeader = "This work is licensed under a [Creative Commons Attribution-NoDerivatives 4.0 International License](http://creativecommons.org/licenses/by-nd/4.0/)."
+```
+
+Or use a different license on individual pages.
+
+```yaml
+licenseHeaderOverride: "Verbatim copying and distribution of this entire article are permitted worldwide, without royalty, in any medium, provided this notice is preserved."
 ```
 
 ### Custom Head HTML

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -221,6 +221,15 @@ Text to display in the footer section
   footer = "Text in footer"
 ```
 
+#### Display a license header
+
+If you copyright your content using the same license, write the header using Markdown.
+
+```toml
+[params]
+  licenseHeader = "This work is licensed under a [Creative Commons Attribution-NoDerivatives 4.0 International License](http://creativecommons.org/licenses/by-nd/4.0/)."
+```
+
 ### Custom Head HTML
 
 You can add custom HTML in head section

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,8 @@
 <footer class="footer">
     <span>&copy; {{ now.Year }} {{ .Site.Params.Footer}}</span>
+    {{ if isset .Site.Params "licenseheader" }}
+        <span>{{ .Site.Params.LicenseHeader | markdownify }}</span>
+    {{ end }}
     <span>
         Made with &#10084;&#65039; using <a target="_blank" href="https://github.com/526avijitgupta/gokarna">Gokarna</a>
     </span>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,8 @@
 <footer class="footer">
     <span>&copy; {{ now.Year }} {{ .Site.Params.Footer}}</span>
-    {{ if isset .Site.Params "licenseheader" }}
+    {{ if isset .Params "licenseheaderoverride" }}
+        <span>{{ .Params.LicenseHeaderOverride | markdownify }}</span>
+        {{ else if isset .Site.Params "licenseheader" }}
         <span>{{ .Site.Params.LicenseHeader | markdownify }}</span>
     {{ end }}
     <span>


### PR DESCRIPTION
Example: ae5e0d26c43965fb0e4e530a556f92143ddacb39 (revert if unwanted)

![Screenshot of license header](https://user-images.githubusercontent.com/109910326/183251513-7f8bbb1d-2838-4fd6-b179-229e603e4cb1.png)

Documentation: 7881161b3b5b724671ef1498082f6c73cf344a70

![Screenshot of documentation](https://user-images.githubusercontent.com/109910326/183251538-c0b7c75f-f47f-463f-b050-c298e3e3373e.png)

Implementation: a4ab53ede7ee1881200c538dbe30d09ac54672db

The `licenseHeader` variable in `config.toml` is used to print a Markdown string in the footer. 

The variable should contain the license header used by the content on your website, in this example [Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0) ](https://creativecommons.org/licenses/by-nd/4.0/).
