### PR TITLE
Add view for empty tags

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -2,6 +2,9 @@
 <div class="container tags-list">
 
     <h1 class="list-title">Tags</h1>
+    {{if eq (len $.Site.Taxonomies.tags) 0}}
+        Nothing to see here, yet 😉
+    {{else}}
     <ul class="post-tags">
         {{ range $.Site.Taxonomies.tags.ByCount }}
         <li class="post-tag">
@@ -12,6 +15,7 @@
         </li>
         {{ end }}
     </ul>
+    {{ end }}
 
 </div>
 {{ end }}


### PR DESCRIPTION
Hello, I've started using this theme and I noticed that in case no tag is present yet, the page is left empty.

Thought would have been nice not to leave the page empty.

This PR adds just a phrase to tell visitors that there are no tags.
