### PR TITLE
Add screen reader support to dark theme button.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,7 @@
 
             <span class="nav-icons-divider"></span>
             <div class="nav-link dark-theme-toggle">
-                <span id="dark-theme-toggle-screen-reader-target" class="sr-only">theme</span>
+                <span id="dark-theme-toggle-screen-reader-target" class="sr-only"></span>
                 <a>
                     <span id="theme-toggle-icon" data-feather="moon"></span>
                 </a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,6 +24,7 @@
 
             <span class="nav-icons-divider"></span>
             <div class="nav-link dark-theme-toggle">
+                <span id="dark-theme-toggle-screen-reader-target" class="sr-only">theme</span>
                 <a>
                     <span id="theme-toggle-icon" data-feather="moon"></span>
                 </a>
@@ -45,6 +46,7 @@
                 </li>
                 {{ end }}
                 <li class="nav-item dark-theme-toggle">
+                    <span id="dark-theme-toggle-screen-reader-target" class="sr-only">theme</span>
                     <a>
                         <span id="theme-toggle-icon" data-feather="moon"></span>
                     </a>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -578,3 +578,13 @@ table td {
     visibility: hidden !important;
   }
 }
+
+/*Accessibility*/
+.sr-only {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -5,6 +5,10 @@ const THEME_TO_ICON_CLASS = {
     'dark': 'feather-moon',
     'light':'feather-sun'
 };
+const THEME_TO_ICON_TEXT_CLASS = {
+    'dark': 'Dark mode',
+    'light':'Light mode'
+};
 let toggleIcon = '';
 let darkThemeCss = '';
 
@@ -102,7 +106,7 @@ function toggleHeaderShadow(scrollY) {
 
 function setThemeByUserPref() {
     darkThemeCss = document.getElementById("dark-theme");
-    const savedTheme = localStorage.getItem(THEME_PREF_STORAGE_KEY) || 
+    const savedTheme = localStorage.getItem(THEME_PREF_STORAGE_KEY) ||
         (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark': 'light');
     const darkThemeToggles = document.querySelectorAll('.dark-theme-toggle');
     setTheme(savedTheme, darkThemeToggles);
@@ -120,7 +124,7 @@ function setTheme(themeToSet, targets) {
     localStorage.setItem(THEME_PREF_STORAGE_KEY, themeToSet);
     darkThemeCss.disabled = themeToSet === 'light';
     targets.forEach((target) => {
-            target.querySelector('a').innerHTML = feather.icons[THEME_TO_ICON_CLASS[themeToSet].split('-')[1]].toSvg();
+        target.querySelector('a').innerHTML = feather.icons[THEME_TO_ICON_CLASS[themeToSet].split('-')[1]].toSvg();
+        target.querySelector("#dark-theme-toggle-screen-reader-target").textContent = [THEME_TO_ICON_TEXT_CLASS[themeToSet]];
     });
 }
-


### PR DESCRIPTION
The dark theme toggle button is currently unreacheable by screen readers (programs blind people use to access the internet).
This adds a target for them, along with some invisible text, matching the state of the icon.

Improvement suggestions welcome.