### PR TITLE
Add  .Lastmod support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,6 +5,7 @@ languageCode = "en"
 defaultContentLanguage = "en"
 enableEmoji = true
 enableRobotsTXT = true
+enableGitInfo = true
 
 # Choose one of emacs, trac or perldoc
 pygmentsStyle = "monokai"

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -3,7 +3,10 @@
         <h1>{{ .Title }}</h1>
         <small role="doc-subtitle">{{ .Description }}</small>
         <p class="post-date">
-            {{ dateFormat "January 2, 2006" .Date }}
+            Posted on {{ dateFormat "January 2, 2006" .Date }}
+        </p>
+        <p class="post-lastmod">
+            Updated on {{ .Lastmod.Format "January 2, 2006" }}
         </p>
 
         <ul class="post-tags">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -428,7 +428,7 @@ table td {
   font-size: 1.1em;
   font-style: italic;
 }
-.post .post-date {
+.post .post-date, .post-lastmod {
   color: gray;
 }
 .post .post-content {


### PR DESCRIPTION
Adding `enableGitInfo = true` to `config.toml` allows the last modified date of the post to be shown.

Example:

![image](https://user-images.githubusercontent.com/109910326/184662692-64ff8934-d57d-4c81-9749-a15c47e0c991.png)

Revert 46d31ac93b4ad3b8d26e2c4556e3d77cc41ba8ec if you don't want this functionality in `exampleSite`.
