### PR TITLE
Added configurable alt text to the avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ git submodule add https://github.com/526avijitgupta/gokarna.git themes/gokarna
 For a complete guide on customization, please go through our [basic](https://gokarna-hugo.netlify.app/posts/theme-documentation-basics/) and [advanced](https://gokarna-hugo.netlify.app/posts/theme-documentation-advanced/) theme documentation. A gist of things you can customize:
 
 - Navigation menu
-- Avatar image and size
+- Avatar image, size, and alt text
 - Accent color
 - Theme mode (Auto, Light & Dark)
 - Custom HTML in head section for loading any scripts

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ git submodule add https://github.com/526avijitgupta/gokarna.git themes/gokarna
 For a complete guide on customization, please go through our [basic](https://gokarna-hugo.netlify.app/posts/theme-documentation-basics/) and [advanced](https://gokarna-hugo.netlify.app/posts/theme-documentation-advanced/) theme documentation. A gist of things you can customize:
 
 - Navigation menu
-- Avatar image, size, and alt text
+- Avatar image and size
 - Accent color
 - Theme mode (Auto, Light & Dark)
 - Custom HTML in head section for loading any scripts

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,6 +13,7 @@ pygmentsStyle = "monokai"
   footer = "The Marauders"
   description = "Sky above, sand below and peace within"
   avatarURL = "/images/avatar.webp"
+  AvatarAltText = "avatar"
   avatarSize = "size-m"
   customHeadHTML = """
     <!-- KaTeX -->

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
 <section class="home-about">
 	<div class="avatar">
         {{ if isset .Site.Params "avatarurl" }}
-        <img class={{ .Site.Params.AvatarSize | default "size-m" }} src='{{ .Site.BaseURL }}{{ .Site.Params.AvatarURL }}'>
+        <img class={{ .Site.Params.AvatarSize | default "size-m" }} src='{{ .Site.BaseURL }}{{ .Site.Params.AvatarURL }}' alt="{{ .Site.Params.AvatarAltText|default "avatar" }}" />
         {{ end }}
 	</div>
     <h1>{{ .Site.Title }}</h1>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,7 +4,7 @@
         {{ if isset .Site.Params "avatarurl" }}
         <div class="avatar">
             <a href="{{ .Site.BaseURL }}">
-                <img src="{{ .Site.BaseURL }}{{ .Site.Params.AvatarURL }}" alt="avatar" />
+                <img src="{{ .Site.BaseURL }}{{ .Site.Params.AvatarURL }}" alt="{{ .Site.Params.AvatarAltText|default "avatar" }}" />
             </a>
         </div>
         {{ end }}


### PR DESCRIPTION
The img avatar in the header already sets alt to "avatar" for screen readers. In most cases, this is enough, however a user may desire a more descriptive alt text. This makes the attribute configurable by the user to make the theme more accessible for blind users since the avatar can now have a description custom-tailored to the desired image, for example a logo with text or a photo of a person or place. Since the img in header.html and index.html pull from the same source, this parameter is applied to both. If the parameter is not set, the alt text will simply default to "avatar" on both. This change is not visible on-screen and will only affect those using screen-reading software.