### PR TITLE
Add invisible screen reader target to mobile menu button.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,6 +31,7 @@
             </div>
 
             <div class="nav-link" id="hamburger-menu-toggle">
+                <span id="hamburger-menu-toggle-screen-reader-target" class="sr-only">menu</span>
                 <a>
                     <span data-feather="menu"></span>
                 </a>


### PR DESCRIPTION
Similarly to the issue with screen readers not finding the dark mode 
toggle button, the mobile view menu button was also unreacheable. This is 
event worse, because it means a blind user is likely to not even know 
there's a menu, when browsing on a phone or with a narrow browser window 
on desktop.
This change fixes the issue the same way.
