### PR TITLE
Add Previous and Next buttons

### DIFF
--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -225,11 +225,13 @@ Text to display in the footer section
 
 At the bottom of a post, show the previous and next post chronologically.
 
-**Warning**: Not compatible with the `.Weight` parameter. [If any post YAML contains `weight: `, the posts will not appear by Date. See [Hugo's default sort](https://gohugo.io/templates/lists#default-weight--date--linktitle--filepath).
+**Warning**: Not compatible with the `.Weight` parameter.
+
+If any post YAML contains `weight:`, the posts will not appear by Date. See [Hugo's default sort](https://gohugo.io/templates/lists#default-weight--date--linktitle--filepath).
 
 ```toml
 [params]
-  togglePreviousAndNextButtons = true
+  togglePreviousAndNextButtons = "true"
 ```
 
 ### Displaying content on the homepage

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -221,6 +221,17 @@ Text to display in the footer section
   footer = "Text in footer"
 ```
 
+### Previous and Next buttons
+
+At the bottom of a post, show the previous and next post chronologically.
+
+**Warning**: Not compatible with the `.Weight` parameter. [If any post YAML contains `weight: `, the posts will not appear by Date. See [Hugo's default sort](https://gohugo.io/templates/lists#default-weight--date--linktitle--filepath).
+
+```toml
+[params]
+  togglePreviousAndNextButtons = true
+```
+
 ### Displaying content on the homepage
 
 Content to display on homepage below the social icons, using the contents of `content/_index.md`.

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -20,6 +20,8 @@
     </div>
 
     <div class="prev-next">
-        {{ partial "prev-next.html" . }}
+        {{ if or .PrevInSection .NextInSection }}
+            {{ partial "prev-next.html" . }}
+        {{ end }}
     </div>
 </div>

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -20,8 +20,10 @@
     </div>
 
     <div class="prev-next">
-        {{ if or .PrevInSection .NextInSection }}
-            {{ partial "prev-next.html" . }}
+        {{ if eq .Site.Params.TogglePreviousAndNextButtons "true" }}
+            {{ if or .PrevInSection .NextInSection }}
+                {{ partial "prev-next.html" . }}
+            {{ end }}
         {{ end }}
     </div>
 </div>

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -18,4 +18,8 @@
             {{ .Content }}
         </p>
     </div>
+
+    <div class="prev-next">
+        {{ partial "prev-next.html" . }}
+    </div>
 </div>

--- a/layouts/partials/prev-next.html
+++ b/layouts/partials/prev-next.html
@@ -1,28 +1,25 @@
-{{ if or .PrevInSection .NextInSection }}
-<hr>
-    {{ with .PrevInSection }}
-    <div class="prev-post">
-        <p>
-            &#8592;
-            Previous:
-            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-        </p>
-        <p class="prev-post-date">
+{{ with .PrevInSection }}
+<div class="prev-post">
+    <p>
+        &#8592;
+        Previous:
+        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+    </p>
+    <p class="prev-post-date">
+        {{ dateFormat "January 2, 2006" .Date }}
+    </p>
+</div>
+{{ end }}
+
+{{ with .NextInSection }}
+<div class="next-post">
+    <p>
+        Next:
+        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        &#8594; 
+    </p>
+        <p class="next-post-date">
             {{ dateFormat "January 2, 2006" .Date }}
         </p>
-    </div>
-    {{ end }}
-
-    {{ with .NextInSection }}
-    <div class="next-post">
-        <p>
-            Next:
-            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-            &#8594; 
-        </p>
-            <p class="next-post-date">
-                {{ dateFormat "January 2, 2006" .Date }}
-            </p>
-    </div>
-    {{ end }}
+</div>
 {{ end }}

--- a/layouts/partials/prev-next.html
+++ b/layouts/partials/prev-next.html
@@ -1,9 +1,11 @@
 {{ with .PrevInSection }}
 <div class="prev-post">
     <p>
-        &#8592;
-        Previous:
-        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        <a href="{{ .RelPermalink }}">
+            &#8592;
+            Previous:
+            {{ .Title }}
+        </a>
     </p>
     <p class="prev-post-date">
         {{ dateFormat "January 2, 2006" .Date }}
@@ -14,9 +16,11 @@
 {{ with .NextInSection }}
 <div class="next-post">
     <p>
-        Next:
-        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-        &#8594; 
+        <a href="{{ .RelPermalink }}">
+            Next:
+            {{ .Title }}
+            &#8594;
+        </a>
     </p>
         <p class="next-post-date">
             {{ dateFormat "January 2, 2006" .Date }}

--- a/layouts/partials/prev-next.html
+++ b/layouts/partials/prev-next.html
@@ -1,0 +1,28 @@
+{{ if or .PrevInSection .NextInSection }}
+<hr>
+    {{ with .PrevInSection }}
+    <div class="prev-post">
+        <p>
+            &#8592;
+            Previous:
+            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        </p>
+        <p class="prev-post-date">
+            {{ dateFormat "January 2, 2006" .Date }}
+        </p>
+    </div>
+    {{ end }}
+
+    {{ with .NextInSection }}
+    <div class="next-post">
+        <p>
+            Next:
+            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+            &#8594; 
+        </p>
+            <p class="next-post-date">
+                {{ dateFormat "January 2, 2006" .Date }}
+            </p>
+    </div>
+    {{ end }}
+{{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -428,7 +428,7 @@ table td {
   font-size: 1.1em;
   font-style: italic;
 }
-.post .post-date, .post-lastmod, .prev-post-date, .next-post-date {
+.post .post-date, .prev-post-date, .next-post-date {
   color: gray;
 }
 .post .post-content {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -428,7 +428,7 @@ table td {
   font-size: 1.1em;
   font-style: italic;
 }
-.post .post-date {
+.post .post-date, .post-lastmod, .prev-post-date, .next-post-date {
   color: gray;
 }
 .post .post-content {
@@ -587,4 +587,18 @@ table td {
   width: 1px;
   height: 1px;
   overflow: hidden;
+}
+
+.prev-post {
+    float: left;
+    text-align: left;
+}
+
+.next-post {
+    float: right;
+    text-align: right;
+}
+
+.prev-post, .next-post {
+    max-width: 33%;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -590,15 +590,15 @@ table td {
 }
 
 .prev-post {
-    float: left;
-    text-align: left;
+  float: left;
+  text-align: left;
 }
 
 .next-post {
-    float: right;
-    text-align: right;
+  float: right;
+  text-align: right;
 }
 
 .prev-post, .next-post {
-    max-width: 33%;
+  max-width: 33%;
 }


### PR DESCRIPTION
# Screenshots

## exampleSite

![Screenshot 2022-09-12 at 16-02-08 Theme Documentation - Basics](https://user-images.githubusercontent.com/109910326/189701798-c9c01949-921e-452d-af2f-5e83d5811f80.png)

### [jamesdavidson.xyz](https://jamesdavidson.xyz/posts/how-to-internally-flash-libreboot-on-a-thinkpad/)

![image](https://user-images.githubusercontent.com/109910326/190651000-9d1e73d6-b154-4dd5-999c-821107c0c11c.png)

# Default sort problem

Sadly, works poorly with `.Weight` due to Hugo's default sort, which prefers `.Weight` over `.Date`:

- https://gohugo.io/variables/page/#page-variables
- https://gohugo.io/templates/lists#default-weight--date--linktitle--filepath

This workaround does not seem to work either: https://www.feliciano.tech/blog/custom-sort-hugo-single-pages/

## Feedback

If you think this is worth adding, I can look into using `.Date` instead of Hugo's default sort.

I'd also appreciate feedback on the CSS, as I'm no designer.