### PR TITLE
Remove prefixed / from tag link on post page

### DIFF
--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -8,7 +8,7 @@
 
         <ul class="post-tags">
         {{ range .Params.tags }}
-            <li class="post-tag"><a href="{{ "/tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a></li>
+            <li class="post-tag"><a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a></li>
         {{ end }}
         </ul>
     </div>


### PR DESCRIPTION
Including a `/` prefix on a call to https://gohugo.io/functions/abslangurl/ prevents it from correctly adding any custom prefixes.

Fixes #129 and #126