### PR TITLE
add rel option for social media icons

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,7 +16,7 @@
     <ul class="social-icons-list">
         {{ range .Site.Params.SocialIcons }}
         <li class="social-icon">
-            <a href="{{ .url }}">
+            <a href="{{ .url }}" {{ if .rel }}rel="{{ .rel }}"{{ end }}>
                 <img class="svg-inject" src="{{ $.Site.BaseURL }}/icons/{{ .name }}.svg" />
             </a>
         </li>


### PR DESCRIPTION
Using `rel=me` on a hyperlink indicates that its destination represents the same person or entity as the current page. Mastodon suggests adding it to verify our presence on the platform establishing a bi-directional rel-me link.

Context http://microformats.org/wiki/relme
Based on https://github.com/luizdepra/hugo-coder/pull/195