### PR TITLE
fix: fix typo which cause ShowPost param not working

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,7 +33,7 @@
 </section>
 {{ end }}
 
-{{ if isset .Site.Params "showpostsonhomepage" }}
+{{ if isset .Site.Params "ShowPostsOnHomePage" }}
 
     <div class="home-posts list-posts">
         <h2>{{ .Site.Params.ShowPostsOnHomePage | humanize }} Posts</h2>


### PR DESCRIPTION
With the `showpostsonhomepage`, the param `showPostsOnHomePage` is not working, although it is set to ""
![image](https://user-images.githubusercontent.com/90588283/201875637-edb35742-17d1-4aa1-8357-8ff3283ddae9.png)
