### PR TITLE
Shrink the post title width to allow wider dates

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -478,6 +478,10 @@ table td {
   display: inline-block;
 }
 .post-title .post-link {
+  /* This magic number is the largest width that keeps the post-date div from
+   *  causing the line to wrap with the longest possible date string
+   *  "September 22, 2022"
+   */
   width: 73%;
 }
 .tags-list .post-tags {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -478,7 +478,7 @@ table td {
   display: inline-block;
 }
 .post-title .post-link {
-  width: 80%;
+  width: 73%;
 }
 .tags-list .post-tags {
   margin-top: 50px;


### PR DESCRIPTION
Fixes #128 

Long date strings like "September 22, 2022" can be wider than the 20% of the width allocated to them, causing the date to wrap around on the posts page.

The width of the post title is lowered from 80% to 73%, the highest width where wrapping never occurs before the mobile CSS breakpoint is hit.