### PR TITLE
Prevent long strings from overflowing

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -428,6 +428,10 @@ table td {
   font-size: 1.1em;
   font-style: italic;
 }
+.post {
+  /* Prevent long strings from overflowing */
+  overflow-wrap: break-word;
+}
 .post .post-date, .prev-post-date, .next-post-date {
   color: gray;
 }


### PR DESCRIPTION
Long strings with no spaces can overflow its container, especially on mobile.

# Without the fix

![image](https://user-images.githubusercontent.com/109910326/208539324-62704874-6483-47a1-90ad-4111dfa095ea.png)

# With the fix

![image](https://user-images.githubusercontent.com/109910326/208539263-4136429d-7e34-4f9f-a65c-1b14c9590dc0.png)

# Relevant documentation

- https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
- https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Text/Wrapping_Text