### PR TITLE
add i18n strings and german translation

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,12 @@
+[Recent]
+    other = 'Letzte'
+[error404]
+    other = 'Diese Seite existiert (noch) nicht, gehen Sie zu zurück auf'
+[home]
+    other = 'Los'
+[nothing]
+    other = 'Hier gibt es noch nichts zu sehen 😉'
+[previous]
+    other = 'Vorheriger Eintrag'
+[next]
+    other = 'Nächster Eintrag'

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,12 @@
+[Recent]
+  other = 'Recent'
+[error404]
+  other = 'This page does not exist, go'
+[home]
+  other = 'home'
+[nothing]
+  other = 'Nothing to see here, yet 😉'
+[previous]
+  other = 'Previous'
+[next]
+  other = 'Next'

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,7 +3,7 @@
 <div class="text-404">
   <h1 class="error-emoji"></h1>
   <h2>
-      404 ... This page does not exist, go <a href="{{ .Site.BaseURL }}">home</a>
+      404 ... {{ i18n "error404" . }} <a href="{{ .Site.BaseURL }}">{{ i18n "home" }}</a>
   </h2>
 </div>
 <script>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,7 +3,7 @@
 
     <h1 class="list-title">Tags</h1>
     {{if eq (len $.Site.Taxonomies.tags) 0}}
-        Nothing to see here, yet 😉
+        {{ i18n "nothing" }}
     {{else}}
     <ul class="post-tags">
         {{ range $.Site.Taxonomies.tags.ByCount }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,7 +36,7 @@
 {{ if isset .Site.Params "showpostsonhomepage" }}
 
     <div class="home-posts list-posts">
-        <h2>{{ .Site.Params.ShowPostsOnHomePage | humanize }} Posts</h2>
+        <h2>{{ i18n (.Site.Params.ShowPostsOnHomePage | humanize) }} Posts</h2>
 
     {{ $posts := where .Site.Pages "Params.type" "post" }}
 

--- a/layouts/partials/prev-next.html
+++ b/layouts/partials/prev-next.html
@@ -3,7 +3,7 @@
     <p>
         <a href="{{ .RelPermalink }}">
             &#8592;
-            Previous:
+            {{ i18n "previous" }}:
             {{ .Title }}
         </a>
     </p>
@@ -17,7 +17,7 @@
 <div class="next-post">
     <p>
         <a href="{{ .RelPermalink }}">
-            Next:
+            {{ i18n "next" }}:
             {{ .Title }}
             &#8594;
         </a>


### PR DESCRIPTION
This PR adds the possibility to translate the hardcoded strings within the template to different languages. German translation is included as example (and for my personal use). Other languages can be added by creating the corresponding files within the folder /i18n.