### PR TITLE
Render Disqus comments if set

### DIFF
--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -17,6 +17,11 @@
         <p>
             {{ .Content }}
         </p>
+        {{ if .Site.DisqusShortname }}
+        <div class="post-comments">
+            {{ template "_internal/disqus.html" . }}
+        </div>
+        {{ end }}
     </div>
 
     <div class="prev-next">


### PR DESCRIPTION
The title says it all. If the `disqusShortname` is set for the site, render it for all posts!