### PR TITLE
Attach event listener with options

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -110,14 +110,16 @@ function setThemeByUserPref() {
         (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark': 'light');
     const darkThemeToggles = document.querySelectorAll('.dark-theme-toggle');
     setTheme(savedTheme, darkThemeToggles);
-    darkThemeToggles.forEach(el => el.addEventListener('click', (event) => {
-        toggleIcon = event.currentTarget.querySelector("a svg.feather");
-        if (toggleIcon.classList[1] === THEME_TO_ICON_CLASS.dark) {
-            setTheme('light', [event.currentTarget]);
-        } else if (toggleIcon.classList[1] === THEME_TO_ICON_CLASS.light) {
-            setTheme('dark', [event.currentTarget]);
-        }
-    }));
+    darkThemeToggles.forEach(el => el.addEventListener('click', toggleTheme, {capture: true}))
+}
+
+function toggleTheme(event) {
+    toggleIcon = event.currentTarget.querySelector("a svg.feather");
+    if (toggleIcon.classList[1] === THEME_TO_ICON_CLASS.dark) {
+        setTheme('light', [event.currentTarget]);
+    } else if (toggleIcon.classList[1] === THEME_TO_ICON_CLASS.light) {
+        setTheme('dark', [event.currentTarget]);
+    }
 }
 
 function setTheme(themeToSet, targets) {


### PR DESCRIPTION
Extracting the theme toggling into a separate function.

**Background:** I use [fireship-io/flamethrower](https://github.com/fireship-io/flamethrower) as a routing and prefetching utility in my page. On every navigation the event listeners were added to the toggle element. by using the option `capture: true` this does not happen anymore.

It does not brake code with this option, although I'll understand that this can be seen as a tailored solution for my problem. Feel free to close this PR with a wont-fix and I will keep it as my personal fork.

Yet I still think it improves readability.
 