### PR TITLE
Only show footer when set

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,9 @@
     {{ .Site.Params.CustomFooterHTML | safeHTML }}
     {{ end }}
 
+    {{ if .Site.Params.footer }}
     <span>&copy; {{ now.Year }} {{ .Site.Params.Footer}}</span>
+    {{ end }}
     <span>
         Made with &#10084;&#65039; using <a target="_blank" href="https://github.com/526avijitgupta/gokarna">Gokarna</a>
     </span>


### PR DESCRIPTION
A very small change to only show the copyright message when the `footer` parameter is set.