### PR TITLE
Change all links to be relative

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -8,7 +8,7 @@
     <ul class="post-tags">
         {{ range $.Site.Taxonomies.tags.ByCount }}
         <li class="post-tag">
-            <a href="{{ $.Site.BaseURL }}/tags/{{ .Name | urlize }}/">
+            <a href="/tags/{{ .Name | urlize }}/">
                 <div class="tag-name">{{ .Name }}</div>
                 <div class="tag-posts-count">{{ .Count }}</div>
             </a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,7 @@
         {{ range .Site.Params.SocialIcons }}
         <li class="social-icon">
             <a href="{{ .url }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} aria-label="Learn more on {{ .name }}">
-                <img class="svg-inject" src="{{ $.Site.BaseURL }}/svg/icons/{{ .name }}.svg" />
+                <img class="svg-inject" src="/svg/icons/{{ .name }}.svg" />
             </a>
         </li>
         {{ end }}


### PR DESCRIPTION
In the Netlify deployment preview the icons do not show up because of CORS. They were served from the old site, because the `BaseURL` is not set correct. This is fixed by using relative links.