### PR TITLE
Move about page above social icons

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,6 +11,12 @@
         <h3>{{ .Site.Params.Description }}</h3>
     {{ end }}
 
+    {{ if os.FileExists "index-about.md" }}
+    <div class="markdown-content">
+        {{ readFile "index-about.md" | markdownify }}
+    </div>
+    {{ end }}
+
 </section>
 
 <div class="flex-break"></div>
@@ -27,12 +33,6 @@
         {{ end }}
     </ul>
 </section>
-{{ end }}
-
-{{ if os.FileExists "index-about.md" }}
-<div class="markdown-content">
-    {{ readFile "index-about.md" | markdownify }}
-</div>
 {{ end }}
 
 {{ if isset .Site.Params "showpostsonhomepage" }}


### PR DESCRIPTION
The pull request named [Add possibility to write text with a markdown "about" file on the title page](https://github.com/526avijitgupta/gokarna/pull/179) by @davidkroell (thank you!) introduced an about section that can be displayed on the landing page.
I'm making this suggestion as the gokarna theme already allowed displaying content on the landing page by creating the file `content/_index.md`, as described [in the documentation](https://gokarna-hugo.netlify.app/posts/theme-documentation-basics/#displaying-content-on-the-homepage). As far as I understand it there's currently no real difference between the two.
At the risk of overlooking or misunderstanding something,  I have intentionally not updated the documentation yet but would do so if this change looks good to you.