### PR TITLE
Add new-page param for target=blank

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,7 +16,7 @@
         <div class="nav-links">
             {{ range .Site.Menus.main }}
             <div class="nav-link">
-                <a href="{{ .URL | absURL }}">
+                <a href="{{ .URL | absURL }}" {{- if .Params.NewPage -}}target="_blank"{{- end -}}>
                     {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
                 </a>
             </div>
@@ -41,7 +41,7 @@
             <ul class="nav-hamburger-list visibility-hidden">
                 {{ range .Site.Menus.main }}
                 <li class="nav-item">
-                    <a href="{{ .URL | absURL }}">
+                    <a href="{{ .URL | absURL }}" {{- if .Params.NewPage -}}target="_blank"{{- end -}}>
                         {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
                     </a>
                 </li>


### PR DESCRIPTION
This PR allows specifying nav menu links to be opened in a new tab.

Config:
```toml
  [[menu.main]]
    identifier = "github"
    url = "https://github.com/zerodahero"
    weight = 4
    # We use feather-icons: https://feathericons.com/
    pre = "<span data-feather='github'></span>"
    [menu.main.params]
      newPage = true
```

Will open the "github" link in a new tab (depending on browser behavior).

If there's an easier way than going through the params, that might be nice as well. I think the  "official" Hugo approach may be to use a `rel = external` param for the menu item--happy to go that route as well if that's more widely understood.