### PR TITLE
Don't wrap {{ .Content }} with p tags

### DIFF
--- a/layouts/partials/page.html
+++ b/layouts/partials/page.html
@@ -5,9 +5,7 @@
     </div>
 
     <div class="post-content">
-        <p>
-            {{ .Content }}
-        </p>
+        {{ .Content }}
     </div>
 </div>
 

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -14,9 +14,7 @@
     </div>
 
     <div class="post-content">
-        <p>
-            {{ .Content }}
-        </p>
+        {{ .Content }}
         {{ if .Site.DisqusShortname }}
         <div class="post-comments">
             {{ template "_internal/disqus.html" . }}


### PR DESCRIPTION
The original template caused the content to be nested inside a pair of p tags (for instance, try viewing the source of https://gokarna-hugo.netlify.app/posts/lorem-ipsum/ vs the fixed version at https://deploy-preview-210--gokarna-hugo.netlify.app/posts/lorem-ipsum/), which causes my browser and the Nu HTML checker to complain about a stray `</p>` tag