### PR TITLE
Fix JS error when ShowBackToTopButton is false

### DIFF
--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -38,7 +38,6 @@
         <!-- Your arrow SVG path or elements go here -->
         <path d="M177 159.7l136 136c9.4 9.4 9.4 24.6 0 33.9l-22.6 22.6c-9.4 9.4-24.6 9.4-33.9 0L160 255.9l-96.4 96.4c-9.4 9.4-24.6 9.4-33.9 0L7 329.7c-9.4-9.4-9.4-24.6 0-33.9l136-136c9.4-9.5 24.6-9.5 34-.1z"/>
     </svg>
-    {{ end }}
     <script>
         let backToTopButton = document.getElementById("btt-button");
 
@@ -69,6 +68,7 @@
             scrollToTop();
         }
     </script>
+    {{ end }}
     {{ if .Site.Params.CustomCommentHTML }}
     <div id="comments">
         {{ .Site.Params.CustomCommentHTML | safeHTML }}


### PR DESCRIPTION
When ShowBackToTopButton is false, the button itself is removed. But the script implementing the button is still running and throwing an error, because it cannot find the expected button element.

This PR removes the script as well as the button, if the setting is turned off