### PR TITLE
Fix link icon styling on mobile

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -184,6 +184,12 @@ img {
   stroke-width: 2;
   width: 20px;
 }
+.nav-item a svg {
+  height: 20px;
+  margin: -3px auto;
+  stroke-width: 2;
+  width: 20px;
+}
 .nav-links .nav-link.icon a {
   padding: 0 8px;
 }


### PR DESCRIPTION
On mobile, all nav links are presented in a hamburger menu. Because this menu uses different CSS classes, some styling for svg icons next to the links was missing and making them look not as great. The icons are off-center and very thin.

![image](https://github.com/526avijitgupta/gokarna/assets/39188180/8c7160b7-3b92-443c-ac98-244606af1470)

This PR adds the same CSS snippet to the links in a hamburger menu.