### PR TITLE
Fix smooth scrolling not changing URL hash

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -27,6 +27,7 @@ html {
   font-size: 17.5px;
   min-height: 100%;
   position: relative;
+  scroll-behavior: smooth;
 }
 
 body {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,7 +27,6 @@ function ready() {
             document.querySelector('main#content > .container').classList.contains('post')) {
         if (document.getElementById('TableOfContents') !== null) {
             fixTocItemsIndent();
-            addSmoothScroll();
             createScrollSpy();
         } else {
             document.querySelector('main#content > .container.post').style.display = "block";
@@ -62,18 +61,6 @@ function fixTocItemsIndent() {
     document.querySelectorAll('#TableOfContents a').forEach($tocItem => {
       const itemId = $tocItem.getAttribute("href").substring(1)
       $tocItem.classList.add(HEADING_TO_TOC_CLASS[document.getElementById(itemId).tagName]);
-    });
-}
-
-function addSmoothScroll() {
-    document.querySelectorAll('#toc a').forEach($anchor => {
-        $anchor.addEventListener('click', function (e) {
-            e.preventDefault();
-            document.getElementById(this.getAttribute('href').substring(1)).scrollIntoView({
-                behavior: 'smooth',
-                block: 'start' //scroll to top of the target element
-            });
-        });
     });
 }
 


### PR DESCRIPTION
Currently, clicking on a link in the table of contents smoothly scrolls the page to the relevant section. For some reason, the URL hash wasn't updated by this though. 

Smooth scrolling is currently implemented in JS. Luckily, there is a single CSS property `scroll-behavior: smooth`, that automatically enables smooth scrolling for all hash links. This PR exchanges the current implementation for this single property.