### PR TITLE
Fix inconsistent font sizing in code blocks on iOS

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -330,6 +330,18 @@ pre code {
   font-size: 0.9em;
 }
 
+/*
+Fix iOS font sizing in code blocks
+Author: https://github.com/bglw
+Source: https://github.com/adityatelange/hugo-PaperMod/issues/828#issuecomment-1171994855
+*/
+code {
+  text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
 blockquote {
   border-left: 2px solid var(--light-secondary-color);
   color: grey;


### PR DESCRIPTION
On iOS, the font sizing is inconsistent in long code blocks. According to this [comment](https://github.com/adityatelange/hugo-PaperMod/issues/828#issuecomment-1171994855), this is an issue with iOS. This PR implements the solution suggested by [bglw](https://github.com/bglw).

I have tested this on my own site and it works as expected.

Before:

![before](https://github.com/526avijitgupta/gokarna/assets/98982999/8ebafbaf-e802-420d-978d-1d4d04665940)

After:

![after](https://github.com/526avijitgupta/gokarna/assets/98982999/05b26fc6-de2c-4346-92da-01ba00ef994d)

