### PR TITLE
Keep using auto theme when unset explicitly

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -103,17 +103,21 @@ function setThemeByUserPref() {
 function toggleTheme(event) {
     toggleIcon = event.currentTarget.querySelector("a svg.feather");
     if (toggleIcon.classList[1] === THEME_TO_ICON_CLASS.dark) {
-        setTheme('light', [event.currentTarget]);
+        setThemeAndStore('light', [event.currentTarget]);
     } else if (toggleIcon.classList[1] === THEME_TO_ICON_CLASS.light) {
-        setTheme('dark', [event.currentTarget]);
+        setThemeAndStore('dark', [event.currentTarget]);
     }
 }
 
 function setTheme(themeToSet, targets) {
-    localStorage.setItem(THEME_PREF_STORAGE_KEY, themeToSet);
     darkThemeCss.disabled = themeToSet === 'light';
     targets.forEach((target) => {
         target.querySelector('a').innerHTML = feather.icons[THEME_TO_ICON_CLASS[themeToSet].split('-')[1]].toSvg();
         target.querySelector(".dark-theme-toggle-screen-reader-target").textContent = [THEME_TO_ICON_TEXT_CLASS[themeToSet]];
     });
+}
+
+function setThemeAndStore(themeToSet, targets) {
+    setTheme(themeToSet, targets);
+    localStorage.setItem(THEME_PREF_STORAGE_KEY, themeToSet);
 }


### PR DESCRIPTION
Hello there!

When the theme loads, it always sets either dark or light mode depending on the OS setting and immediately stores it in local storage. Meaning, if a user initially visits a site in the night, it will be dark forever or until changed by clicking on the icon. And vice versa.

This is a confusing behavior, this patch changes the logic - until the icon is clicked and setting explicitly set by a user, it follows the OS. The change is simple - local storage is not written on page request.

To test this feature:

* Delete webpage local storage settings via browser functionality.
* Visit the page in dark OS setting.
* Visit the page in light OS setting.
* The theme should follow until the "bulb" icon is clicked.