### PR TITLE
Fix ".Site.DisqusShortname was deprecated in Hugo v0.120.0".

### DIFF
--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -15,7 +15,7 @@
 
     <div class="post-content">
         {{ .Content }}
-        {{ if .Site.DisqusShortname }}
+        {{ if .Site.Config.Services.Disqus.Shortname }}
         <div class="post-comments">
             {{ template "_internal/disqus.html" . }}
         </div>


### PR DESCRIPTION
I have fixed the following warning:

```
WARN  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.
```