### PR TITLE
Fix back to top button not working

### DIFF
--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -32,7 +32,7 @@
 
     <!-- Back to top button -->
     {{ if .Site.Params.ShowBackToTopButton }}
-    <svg id="btt-button" class="arrow-logo" xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 384 512" onclick="topFunction()" title="Go to top">
+    <svg id="btt-button" class="arrow-logo" xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 384 512" onclick="scrollToTop()" title="Go to top">
         <!-- Your arrow SVG path or elements go here -->
         <path d="M177 159.7l136 136c9.4 9.4 9.4 24.6 0 33.9l-22.6 22.6c-9.4 9.4-24.6 9.4-33.9 0L160 255.9l-96.4 96.4c-9.4 9.4-24.6 9.4-33.9 0L7 329.7c-9.4-9.4-9.4-24.6 0-33.9l136-136c9.4-9.5 24.6-9.5 34-.1z"/>
     </svg>
@@ -51,19 +51,8 @@
             }
         }
 
-        function topFunction() {
-            smoothScrollToTop();
-        }
-
-        function smoothScrollToTop() {
-            const scrollToTop = () => {
-                const c = document.documentElement.scrollTop || document.body.scrollTop;
-                if (c > 0) {
-                    window.requestAnimationFrame(scrollToTop);
-                    window.scrollTo(0, c - c / 8);
-                }
-            };
-            scrollToTop();
+        function scrollToTop() {
+            window.scrollTo(0, 0);
         }
     </script>
     {{ end }}


### PR DESCRIPTION
Since `scroll-behavior: smooth` is applied in #213 , back to top button didn't work in Google Chrome.

This is a known issue that Chrome calls `requestAnimationFrame` in every tick.

https://stackoverflow.com/questions/73052119/scroll-behavior-smooth-doesnt-work-on-html-in-chrome

I think there is no need call `smoothScrollToTop` function and just calling `window.scrollTo` is fine, because we already have `scroll-behavior: smooth`.