### PR TITLE
Add a "hiddenTags" Params field

### DIFF
--- a/layouts/partials/list-posts.html
+++ b/layouts/partials/list-posts.html
@@ -1,5 +1,3 @@
 <div class="post-title">
     <a href="{{ .Permalink }}" class="post-link">{{ .Title }}</a>
-    <div class="flex-break"></div>
-    <span class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}</span>
 </div>

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -7,9 +7,12 @@
         </p>
 
         <ul class="post-tags">
-        {{ range .Params.tags }}
-            <li class="post-tag"><a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a></li>
-        {{ end }}
+	 {{ $hiddenTags := .Site.Params.HiddenTags }}
+         {{ range $tag := .Params.tags }}
+           {{ if not (in $hiddenTags $tag) }}
+             <li class="post-tag"><a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a></li>
+           {{ end }}
+         {{ end }}
         </ul>
     </div>
 


### PR DESCRIPTION
All tags listed in hiddenTags aren't displayed on the posts.
Tags can be used to categorize posts, and categories don't need to be displayed.

An example is if the pages are used for about-us and contact, and posts as blog articles and projects presentation.
Example of hugo.toml using this new field:

[params]
hiddenTags = ["project", "blog"]
[menu]
[[menu.main]]
  identifier = "projects"
  url = "/tags/project/"
  name = "My Projects"
  weight = 1
[[menu.main]]
  identifier = "blog"
  url = "/tags/blog/"
  name = "Blog"
  weight = 2