### PR TITLE
All tags listed in hiddenTags aren't displayed on the posts.

### DIFF
--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -317,3 +317,24 @@ and the `metaKeywords` specified in the config.toml:
 [params]
   metaKeywords = ["blog", "gokarna", "hugo"]
 ```
+
+## Hide tags
+
+Tags can be used to categorize posts (e.g.: Project or Blog), and be hidden on
+the posts. Simply set the `params.hiddenTags` field in `hugo.toml`.
+
+```toml
+[params]
+  hiddenTags = ["project", "blog"]
+  [menu]
+    [[menu.main]]
+      identifier = "projects"
+      url = "/tags/project/"
+      name = "My Projects"
+      weight = 1
+    [[menu.main]]
+      identifier = "blog"
+      url = "/tags/blog/"
+      name = "Blog"
+      weight = 2
+```

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -7,9 +7,12 @@
         </p>
 
         <ul class="post-tags">
-        {{ range .Params.tags }}
-            <li class="post-tag"><a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a></li>
-        {{ end }}
+	 {{ $hiddenTags := .Site.Params.HiddenTags }}
+          {{ range $tag := .Params.tags }}
+           {{ if not (in $hiddenTags $tag) }}
+             <li class="post-tag"><a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a></li>
+           {{ end }}
+         {{ end }}
         </ul>
     </div>
 


### PR DESCRIPTION
Tags can be used to categorize posts, and categories don't need to be displayed.

An example is if the pages are used for about-us and contact, and posts as blog articles and projects presentation. Example of hugo.toml using this new field:

[params]
hiddenTags = ["project", "blog"]
[menu]
[[menu.main]]
identifier = "projects"
url = "/tags/project/"
name = "My Projects"
weight = 1
[[menu.main]]
identifier = "blog"
url = "/tags/blog/"
name = "Blog"
weight = 2