### PR TITLE
Hide some informations about the posts

### DIFF
--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -328,9 +328,10 @@ A post's date and description can be hidden if it has at least one tag listed in
 
 ```toml
 [params]
-  hiddenTags = ["project", "blog"]
-  tagsHidePostDate = ["project"]
-  tagsHidePostDescription = ["project"]
+  [params.hidden]
+  tags = ["project", "blog"]
+  tagsPostDate = ["project"]
+  tagsPostDescription = ["project"]
   [menu]
     [[menu.main]]
       identifier = "projects"

--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -318,7 +318,7 @@ and the `metaKeywords` specified in the config.toml:
   metaKeywords = ["blog", "gokarna", "hugo"]
 ```
 
-## Hide posts' tags, date and description
+## Hide tags, date or description of posts
 
 Tags can be used to categorize posts (e.g.: Project or Blog), and be hidden on
 the posts. Use the `params.hiddenTags` field in `hugo.toml`.  

--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -318,14 +318,19 @@ and the `metaKeywords` specified in the config.toml:
   metaKeywords = ["blog", "gokarna", "hugo"]
 ```
 
-## Hide tags
+## Hide posts' tags, date and description
 
 Tags can be used to categorize posts (e.g.: Project or Blog), and be hidden on
-the posts. Simply set the `params.hiddenTags` field in `hugo.toml`.
+the posts. Use the `params.hiddenTags` field in `hugo.toml`.  
+A post's date and description can be hidden if it has at least one tag listed in
+`params.tagsHidePostDate` or `params.tagsHidePostDescription`, respectively.
+
 
 ```toml
 [params]
   hiddenTags = ["project", "blog"]
+  tagsHidePostDate = ["project"]
+  tagsHidePostDescription = ["project"]
   [menu]
     [[menu.main]]
       identifier = "projects"

--- a/layouts/partials/list-posts.html
+++ b/layouts/partials/list-posts.html
@@ -1,5 +1,18 @@
 <div class="post-title">
-    <a href="{{ .Permalink }}" class="post-link">{{ .Title }}</a>
-    <div class="flex-break"></div>
-    <span class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}</span>
+     <a href="{{ .Permalink }}" class="post-link">{{ .Title }}</a>
+     {{/* Display the date only if the post doesn't have a tag listed in tagsHidePostDate */}}
+     {{ $displayDate := true }}
+     {{ if isset .Site.Params "tagshidepostdate" }}
+      {{ $tagsHidePostDate := .Site.Params.TagsHidePostDate }}
+      {{ range $tag := .Params.Tags }}
+       {{ if in $tagsHidePostDate $tag }}
+        {{ $displayDate = false }}
+       {{ end }}
+      {{ end }}
+     {{ end }}
+
+    {{ if eq $displayDate true }}
+     <div class="flex-break"></div>
+     <span class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}</span>
+    {{ end }}
 </div>

--- a/layouts/partials/list-posts.html
+++ b/layouts/partials/list-posts.html
@@ -1,18 +1,16 @@
 <div class="post-title">
      <a href="{{ .Permalink }}" class="post-link">{{ .Title }}</a>
-     {{/* Display the date only if the post doesn't have a tag listed in tagsHidePostDate */}}
+     {{/* Decide to display the date based on the tags */}}
      {{ $displayDate := true }}
-     {{ if isset .Site.Params "tagshidepostdate" }}
-      {{ $tagsHidePostDate := .Site.Params.TagsHidePostDate }}
-      {{ range $tag := .Params.Tags }}
-       {{ if in $tagsHidePostDate $tag }}
-        {{ $displayDate = false }}
-       {{ end }}
-      {{ end }}
+     {{ $tagsHidePostDate := or .Site.Params.Hidden.TagsPostDate slice }}
+     {{ $postTags := or .Params.Tags slice }}
+
+     {{ if gt ($tagsHidePostDate | intersect $postTags | len) 0 }}
+       {{ $displayDate = false }}
      {{ end }}
 
-    {{ if eq $displayDate true }}
-     <div class="flex-break"></div>
-     <span class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}</span>
-    {{ end }}
+     {{ if eq $displayDate true }}
+      <div class="flex-break"></div>
+      <span class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}</span>
+     {{ end }}
 </div>

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -24,11 +24,11 @@
          {{ end }}
         {{ end }}
 
-	{{ if eq $displayDescription true }}
+	{{ if $displayDescription }}
           <small role="doc-subtitle">{{ .Description }}</small>
 	{{ end }}
 
-	{{ if eq $displayDate true }}
+	{{ if $displayDate }}
           <p class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}
            {{ if lt .Date .Lastmod }} | Updated {{ dateFormat .Site.Params.dateFormat .Lastmod }}{{ end }}
           </p>

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -1,10 +1,38 @@
 <div class="post container">
     <div class="post-header-section">
         <h1>{{ .Title }}</h1>
-        <small role="doc-subtitle">{{ .Description }}</small>
-        <p class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}
-        {{ if lt .Date .Lastmod }} | Updated {{ dateFormat .Site.Params.dateFormat .Lastmod }}{{ end }}
-        </p>
+
+        {{/* Display the date only if the post doesn't have a tag listed in tagsHidePostDate */}}
+        {{ $displayDate := true }}
+        {{ if isset .Site.Params "tagshidepostdate" }}
+         {{ $tagsHidePostDate := .Site.Params.TagsHidePostDate }}
+         {{ range $tag := .Params.Tags }}
+          {{ if in $tagsHidePostDate $tag }}
+           {{ $displayDate = false }}
+          {{ end }}
+         {{ end }}
+        {{ end }}
+
+        {{/* Display the description only if the post doesn't have a tag listed in tagsHidePostDescription */}}
+        {{ $displayDescription := true }}
+        {{ if isset .Site.Params "tagshidepostdescription" }}
+         {{ $tagsHidePostDescription := .Site.Params.TagsHidePostDescription }}
+         {{ range $tag := .Params.Tags }}
+          {{ if in $tagsHidePostDescription $tag }}
+           {{ $displayDescription = false }}
+          {{ end }}
+         {{ end }}
+        {{ end }}
+
+	{{ if eq $displayDescription true }}
+          <small role="doc-subtitle">{{ .Description }}</small>
+	{{ end }}
+
+	{{ if eq $displayDate true }}
+          <p class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}
+           {{ if lt .Date .Lastmod }} | Updated {{ dateFormat .Site.Params.dateFormat .Lastmod }}{{ end }}
+          </p>
+	{{ end }}
 
         <ul class="post-tags">
 	 {{ $hiddenTags := .Site.Params.HiddenTags }}

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -2,26 +2,25 @@
     <div class="post-header-section">
         <h1>{{ .Title }}</h1>
 
-        {{/* Display the date only if the post doesn't have a tag listed in tagsHidePostDate */}}
+        {{/* Determine whether to display the date & description based on tags */}}
+
         {{ $displayDate := true }}
-        {{ if isset .Site.Params "tagshidepostdate" }}
-         {{ $tagsHidePostDate := .Site.Params.TagsHidePostDate }}
-         {{ range $tag := .Params.Tags }}
-          {{ if in $tagsHidePostDate $tag }}
-           {{ $displayDate = false }}
-          {{ end }}
-         {{ end }}
+	{{ $displayDescription := true }}
+	{{ $tagsHidePostDate := slice }}
+        {{ $tagsHidePostDescription := slice }}
+
+        {{ with .Site.Params }}
+            {{ $tagsHidePostDate = .TagsHidePostDate | default slice }}
+            {{ $tagsHidePostDescription = .TagsHidePostDescription | default slice }}
         {{ end }}
 
-        {{/* Display the description only if the post doesn't have a tag listed in tagsHidePostDescription */}}
-        {{ $displayDescription := true }}
-        {{ if isset .Site.Params "tagshidepostdescription" }}
-         {{ $tagsHidePostDescription := .Site.Params.TagsHidePostDescription }}
-         {{ range $tag := .Params.Tags }}
-          {{ if in $tagsHidePostDescription $tag }}
-           {{ $displayDescription = false }}
-          {{ end }}
-         {{ end }}
+        {{ range .Params.Tags }}
+            {{ if in $tagsHidePostDate . }}
+                {{ $displayDate = false }}
+            {{ end }}
+            {{ if in $tagsHidePostDescription . }}
+                {{ $displayDescription = false }}
+            {{ end }}
         {{ end }}
 
 	{{ if $displayDescription }}

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -6,22 +6,18 @@
 
         {{ $displayDate := true }}
 	{{ $displayDescription := true }}
-	{{ $tagsHidePostDate := slice }}
-        {{ $tagsHidePostDescription := slice }}
+	{{ $postTags := or .Params.Tags slice }}
+	{{ $hiddenTags := or .Site.Params.Hidden.Tags slice }}
+	{{ $tagsHidePostDate := or .Site.Params.Hidden.TagsPostDate slice }}
+        {{ $tagsHidePostDescription := or .Site.Params.Hidden.TagsPostDescription slice }}
 
-        {{ with .Site.Params }}
-            {{ $tagsHidePostDate = .TagsHidePostDate | default slice }}
-            {{ $tagsHidePostDescription = .TagsHidePostDescription | default slice }}
-        {{ end }}
+	{{ if gt ($tagsHidePostDate | intersect $postTags | len) 0 }}
+	  {{ $displayDate = false }}
+	{{ end }}
 
-        {{ range .Params.Tags }}
-            {{ if in $tagsHidePostDate . }}
-                {{ $displayDate = false }}
-            {{ end }}
-            {{ if in $tagsHidePostDescription . }}
-                {{ $displayDescription = false }}
-            {{ end }}
-        {{ end }}
+	{{ if gt ($tagsHidePostDescription | intersect $postTags | len) 0 }}
+	  {{ $displayDescription = false }}
+	{{ end }}
 
 	{{ if $displayDescription }}
           <small role="doc-subtitle">{{ .Description }}</small>
@@ -34,8 +30,7 @@
 	{{ end }}
 
         <ul class="post-tags">
-	 {{ $hiddenTags := .Site.Params.HiddenTags }}
-          {{ range $tag := .Params.tags }}
+          {{ range $tag := $postTags }}
            {{ if not (in $hiddenTags $tag) }}
              <li class="post-tag"><a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a></li>
            {{ end }}


### PR DESCRIPTION
Based on how the posts are used (e.g. to describe projects or blog posts), it can be useful to hide the date or the description. Using the fields `params.tagsHidePostDate` and
`params.tagsHidePostDescription`, it's possible.