### PR TITLE
Add a missing space between HTML attributes

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,7 +16,11 @@
         <div class="nav-links">
             {{ range .Site.Menus.main }}
             <div class="nav-link">
-                <a href="{{ .URL | absURL }}" {{- if .Params.NewPage -}}target="_blank"{{- end -}}>
+	      {{ $target := "_self" }}
+	      {{ if .Params.NewPage }}
+	       {{ $target = "_blank" }}
+	      {{ end }}
+                <a href="{{ .URL | absURL }}" target="{{ $target }}">
                     {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
                 </a>
             </div>
@@ -41,7 +45,11 @@
             <ul class="nav-hamburger-list visibility-hidden">
                 {{ range .Site.Menus.main }}
                 <li class="nav-item">
-                    <a href="{{ .URL | absURL }}" {{- if .Params.NewPage -}}target="_blank"{{- end -}}>
+		  {{ $target := "_self" }}
+	          {{ if .Params.NewPage }}
+	           {{ $target = "_blank" }}
+	          {{ end }}
+                    <a href="{{ .URL | absURL }}" target="{{ $target }}">
                         {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
                     </a>
                 </li>


### PR DESCRIPTION
With the space between the attributes, HTML is compliant.