### PR TITLE
Add a space between HTML attributes in header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,7 +16,7 @@
         <div class="nav-links">
             {{ range .Site.Menus.main }}
             <div class="nav-link">
-                <a href="{{ .URL | absURL }}" {{- if .Params.NewPage -}}target="_blank"{{- end -}}>
+                <a href="{{ .URL | absURL }}" {{ if .Params.NewPage -}}target="_blank" {{- end -}}>
                     {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
                 </a>
             </div>
@@ -41,7 +41,7 @@
             <ul class="nav-hamburger-list visibility-hidden">
                 {{ range .Site.Menus.main }}
                 <li class="nav-item">
-                    <a href="{{ .URL | absURL }}" {{- if .Params.NewPage -}}target="_blank"{{- end -}}>
+                    <a href="{{ .URL | absURL }}" {{ if .Params.NewPage -}} target="_blank"{{- end -}}>
                         {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
                     </a>
                 </li>


### PR DESCRIPTION
The links added to the menu were missing spaces between their attributes. It's now present, making the HTML compliant.

This time it's done on one line, my replacing {{- by {{. It seems the dash is a space controller.