### PR TITLE
Optimize pages meta description and index page  social icon

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,7 +21,7 @@
         {{ range .Site.Params.SocialIcons }}
         <li class="social-icon">
             <a href="{{ .url }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} aria-label="Learn more on {{ .name }}">
-                <img class="svg-inject" src="/svg/icons/{{ .name }}.svg" alt="">
+                <img class="svg-inject" src="/svg/icons/{{ .name | lower }}.svg" alt="">
             </a>
         </li>
         {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,11 +9,12 @@
     </style>
 
     {{ $title := .Title | default .Site.Title }}
-    {{ $description := .Description | default .Site.Params.Description }}
+    {{ $description := ((.Description | default (.Summary | default (.Content | plainify)) | default .Site.Params.Description) | truncate 160) }}
     {{ $image := .Params.image | default (.Scratch.Get "avatarImgSrc") }}
     {{ $siteKeywords := .Site.Params.MetaKeywords | default (slice) }}
     {{ $postKeywords := .Params.tags | default (slice) }}
     {{ $keywords := union $siteKeywords $postKeywords }}
+    {{ $hasTwitter := false }}{{ range .Site.Params.socialIcons }}{{ if eq (lower .name) "twitter" }}{{ $hasTwitter = true }}{{ end }}{{ end }}
 
     <!-- SEO titles & descriptions -->
     <title>{{ $title }}</title>
@@ -27,12 +28,14 @@
     <meta property="og:image" content="{{ absURL $image }}">
     <meta property="og:image:secure_url" content="{{ absURL $image }}">
 
+    {{ if $hasTwitter }}
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{ $title }}">
     <meta name="twitter:description" content="{{ $description }}">
     <meta property="twitter:domain" content="{{ .Permalink }}">
     <meta property="twitter:url" content="{{ .Permalink }}">
     <meta name="twitter:image" content="{{ absURL $image }}">
+    {{ end }}
 
     <!-- SEO canonicals: helps Google understand your site better when using marketing campaign tagging etc -->
     <link rel="canonical" href="{{ .Permalink }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,7 +14,6 @@
     {{ $siteKeywords := .Site.Params.MetaKeywords | default (slice) }}
     {{ $postKeywords := .Params.tags | default (slice) }}
     {{ $keywords := union $siteKeywords $postKeywords }}
-    {{ $hasTwitter := false }}{{ range .Site.Params.socialIcons }}{{ if eq (lower .name) "twitter" }}{{ $hasTwitter = true }}{{ end }}{{ end }}
 
     <!-- SEO titles & descriptions -->
     <title>{{ $title }}</title>
@@ -28,14 +27,12 @@
     <meta property="og:image" content="{{ absURL $image }}">
     <meta property="og:image:secure_url" content="{{ absURL $image }}">
 
-    {{ if $hasTwitter }}
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{ $title }}">
     <meta name="twitter:description" content="{{ $description }}">
     <meta property="twitter:domain" content="{{ .Permalink }}">
     <meta property="twitter:url" content="{{ .Permalink }}">
     <meta name="twitter:image" content="{{ absURL $image }}">
-    {{ end }}
 
     <!-- SEO canonicals: helps Google understand your site better when using marketing campaign tagging etc -->
     <link rel="canonical" href="{{ .Permalink }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,7 +9,7 @@
     </style>
 
     {{ $title := .Title | default .Site.Title }}
-    {{ $description := ((.Description | default (.Summary | default (.Content | plainify)) | default .Site.Params.Description) | truncate 160) }}
+    {{ $description := ((.Description | default (.Summary | default .Content) | default .Site.Params.Description) | plainify | truncate 160) }}
     {{ $image := .Params.image | default (.Scratch.Get "avatarImgSrc") }}
     {{ $siteKeywords := .Site.Params.MetaKeywords | default (slice) }}
     {{ $postKeywords := .Params.tags | default (slice) }}


### PR DESCRIPTION
There has three changes:
1. Limit description length as 160 charactors for SEO.
2. Fixed issue of icon url not found if socialIcons name in different case.