### PR TITLE
feat: display accurate copyright years on pages

### DIFF
--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -344,3 +344,24 @@ A post's date and description can be hidden if it has at least one tag listed in
       name = "Blog"
       weight = 2
 ```
+
+## Site-wide copyright notice
+
+Define the [copyright notice for your site](https://gohugo.io/methods/site/copyright/). The notice will only be displayed on [page Kinds](#content-types).
+
+For example, the following configuration in `config.toml` and front matter respectively...
+
+```toml
+copyright = "Verbatim copying and distribution of this entire article are permitted worldwide, without royalty, in any medium, provided this notice is preserved."
+```
+
+```
+date: 2020-06-17
+lastmod: 2024-02-05
+```
+
+Will produce this footer:
+
+> © 2020-2024 The Marauders Verbatim copying and distribution of this entire article are permitted worldwide, without royalty, in any medium, provided this notice is preserved.
+
+The years of `.Date` and `.Lastmod` are used to create a date range for your copyrighted material. [dateFormat](/posts/theme-documentation-basics/#date-format) **must** be set in `config.toml` if `.Lastmod` is present in any front matter.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,9 +4,17 @@
     {{ .Site.Params.CustomFooterHTML | safeHTML }}
     {{ end }}
 
-    {{ if .Site.Params.footer }}
-    <span>&copy; {{ now.Year }} {{ .Site.Params.Footer}}</span>
+    {{/* Print a year range if .Date and .Lastmod are present */}}
+    {{ if and (.Date) (.Lastmod) (.Site.Params.Footer) (eq .Kind "page") (gt (time.Format "2006" .Lastmod) (time.Format "2006" .Date)) }}
+    <span>&copy; {{ time.Format "2006" .Date }}-{{ time.Format "2006" .Lastmod }} {{ .Site.Params.Footer }} {{ .Site.Copyright }}</span>
+    {{/* Use .Date as the copyright year */}}
+    {{ else if and (.Date) (.Site.Params.Footer) (eq .Kind "page") }}
+        <span>&copy; {{ time.Format "2006" .Date }} {{ .Site.Params.Footer }} {{ .Site.Copyright }}</span>
+    {{/* Use the current year for other Kinds, and pages without Date or Lastmod */}}
+    {{ else if (.Site.Params.Footer) }}
+        <span>&copy; {{ now.Year }} {{ .Site.Params.Footer }}</span>
     {{ end }}
+
     <span>
         Made with &#10084;&#65039; using <a target="_blank" href="https://github.com/526avijitgupta/gokarna">Gokarna</a>
     </span>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,15 +4,33 @@
     {{ .Site.Params.CustomFooterHTML | safeHTML }}
     {{ end }}
 
-    {{/* Print a year range if .Date and .Lastmod are present */}}
-    {{ if and (.Date) (.Lastmod) (.Site.Params.Footer) (eq .Kind "page") (gt (time.Format "2006" .Lastmod) (time.Format "2006" .Date)) }}
-    <span>&copy; {{ time.Format "2006" .Date }}-{{ time.Format "2006" .Lastmod }} {{ .Site.Params.Footer }} {{ .Site.Copyright }}</span>
-    {{/* Use .Date as the copyright year */}}
-    {{ else if and (.Date) (.Site.Params.Footer) (eq .Kind "page") }}
-        <span>&copy; {{ time.Format "2006" .Date }} {{ .Site.Params.Footer }} {{ .Site.Copyright }}</span>
-    {{/* Use the current year for other Kinds, and pages without Date or Lastmod */}}
-    {{ else if (.Site.Params.Footer) }}
-        <span>&copy; {{ now.Year }} {{ .Site.Params.Footer }}</span>
+    {{ .Scratch.Set "footerText" "" }}
+
+    {{ if (.Site.Params.Footer) }}
+
+        {{ if and (eq .Kind "page") (.Date) }}
+            {{ .Scratch.Add "footerText" (.Date | time.Format "2006") }}
+        {{ else }}
+            {{ .Scratch.Add "footerText" (time.Now | time.Format "2006") }}
+        {{ end }}
+
+        {{ if and (eq .Kind "page") (.Lastmod) (gt (time.Format "2006" .Lastmod) (time.Format "2006" .Date)) }}
+            {{ .Scratch.Add "footerText" "-" }}
+            {{ .Scratch.Add "footerText" (.Lastmod | time.Format "2006") }}
+        {{ end }}
+
+        {{ .Scratch.Add "footerText" " " }}
+        {{ .Scratch.Add "footerText" .Site.Params.Footer }}
+
+        {{ if and (eq .Kind "page") (.Site.Copyright) }}
+            {{ .Scratch.Add "footerText" " " }}
+            {{ .Scratch.Add "footerText" .Site.Copyright }}
+        {{ end }}
+
+    {{ end }}
+
+    {{ if (gt (.Scratch.Get "footerText" | len) 0) }}
+        <span>&copy; {{ .Scratch.Get "footerText" }}</span>
     {{ end }}
 
     <span>


### PR DESCRIPTION
tl;dr Implementation for #222.

- Pages which are *not* of kind `page` continue to use `now.Year`
- Pages which do *not* declare `.Date` also use `now.Year`
- Pages which declare `.Date` use it *instead* of `now.Year`
- Pages which declare `.Lastmod` and `.Date` use both dates in a range, *instead* of `now.Year`

A long `copyright` string will overflow the `.footer` container, ergo some assistance on the CSS side would be greatly appreciated. :smiley: 

N.B. Copyright is described by Hugo here: https://gohugo.io/methods/site/copyright/

- [ ] css fixes
- [x] docs (advanced)
- [x] screenshots
-  ~~config opt-in *?*~~
   ~~`copyright` is only displayed if it exists in `config.toml`; I'd argue this isn't necessary~~
- ~~add `dateFormat` to `config.toml` *?*~~
   - ~~add `Lastmod` to any relevant `exampleSite` pages for illustration *?*~~