### PR TITLE
feat: markdownify footerText

### DIFF
--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -364,4 +364,6 @@ Will produce this footer:
 
 > © 2020-2024 The Marauders Verbatim copying and distribution of this entire article are permitted worldwide, without royalty, in any medium, provided this notice is preserved.
 
+`copyright` can include [Markdown syntax](https://www.markdownguide.org/tools/hugo/). This is best used for including hyperlinks, emoji, or text formatting.
+
 The years of `.Date` and `.Lastmod` are used to create a date range for your copyrighted material. [dateFormat](/posts/theme-documentation-basics/#date-format) **must** be set in `config.toml` if `.Lastmod` is present in any front matter.

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -230,6 +230,8 @@ Text to display in the footer section
   footer = "Text in footer"
 ```
 
+`footer` can include [Markdown syntax](https://www.markdownguide.org/tools/hugo/). This is best used for including hyperlinks, emoji, or text formatting.
+
 ### Previous and Next buttons
 
 At the bottom of a post, show the previous and next post chronologically.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -30,7 +30,7 @@
     {{ end }}
 
     {{ if (gt (.Scratch.Get "footerText" | len) 0) }}
-        <span>&copy; {{ .Scratch.Get "footerText" }}</span>
+        <span>&copy; {{ .Scratch.Get "footerText" | markdownify }}</span>
     {{ end }}
 
     <span>


### PR DESCRIPTION
`footer` and `copyright` can include Markdown syntax. As mentioned in the docs:

> This is best used for including hyperlinks, emoji, or text formatting.

Screenshot example:

![image](https://github.com/user-attachments/assets/449d9acc-5686-41f2-a651-261b2ac988b7)

N.B. I omitted this during testing (#233) and forgot to re-implement. Apologies :grin: 