### PR TITLE
Option for number of posts on homepage, Polish translation

### DIFF
--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -161,6 +161,10 @@ In addition to [Hugo global configuration](https://gohugo.io/overview/configurat
   # or "" (do not display, default option)
   showPostsOnHomePage = ""
 
+  # Defines number of posts displayed on homepage if showPostsOnHomePage option is set
+  # Default value is 5
+  numberPostsOnHomePage = 4
+
   # Footer text
   footer = "The Marauders"
 ```
@@ -208,9 +212,12 @@ If you want to display posts on the homepage, the options are:
 - `recent`: Show recent posts on home page if the value is set to recent
 - Do not show anything if the variable is unset or an empty string.
 
+You can define how many posts will be displayed on homepage by setting `numberPostsOnHomePage`. If `numberPostsOnHomePage` is absent (empty) or zero the default value is used.
+
 ```toml
 [params]
   showPostsOnHomePage = "popular"
+  numberPostsOnHomePage = 3
 ```
 
 ### Date format 

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -162,7 +162,7 @@ In addition to [Hugo global configuration](https://gohugo.io/overview/configurat
   showPostsOnHomePage = ""
 
   # Defines number of posts displayed on homepage if showPostsOnHomePage option is set
-  # Default value is 5
+  # Default value is 4
   numberPostsOnHomePage = 4
 
   # Footer text

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,5 +1,7 @@
 [Recent]
-    other = 'Letzte'
+    other = 'Letzte Einträge'
+[Popular]
+    others = 'Einträge'
 [error404]
     other = 'Diese Seite existiert (noch) nicht, gehen Sie zu zurück auf'
 [home]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,5 +1,7 @@
 [Recent]
-  other = 'Recent'
+  other = 'Recent Posts'
+[Popular]
+  other = 'Posts'
 [error404]
   other = 'This page does not exist, go'
 [home]

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -1,5 +1,7 @@
 [Recent]
-  other = 'Recientes'
+  other = 'Recientes entradas'
+[Popular]
+  other = 'Entradas'
 [error404]
   other = 'Esta página no existe, prueba de nuevo desde el'
 [home]

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -1,0 +1,16 @@
+[Recent]
+  other = 'Ostatnie posty'
+[Popular]
+  other = 'Posty'
+[error404]
+  other = 'Ta strona nie istnieje, przejdź na '
+[home]
+  other = 'start'
+[nothing]
+  other = 'Na razie tu nic nie ma 😉'
+[previous]
+  other = 'Poprzedni'
+[next]
+  other = 'Następny'
+[tags]
+  other = 'Tagi'

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -38,16 +38,16 @@
 {{ if isset .Site.Params "showpostsonhomepage" }}
 
     <div class="home-posts list-posts">
-        <h2>{{ i18n (.Site.Params.ShowPostsOnHomePage | humanize) }} Posts</h2>
+        <h2>{{ i18n (.Site.Params.ShowPostsOnHomePage | humanize) }}</h2>
 
     {{ $posts := where .Site.Pages "Params.type" "post" }}
 
     {{ if eq .Site.Params.ShowPostsOnHomePage "popular" }}
-        {{ range $posts.ByWeight | first 4 }}
+        {{ range $posts.ByWeight | first (or .Site.Params.NumberPostsOnHomePage 4) }}
             {{- partial "list-posts.html" . -}}
         {{ end }}
     {{ else if eq .Site.Params.ShowPostsOnHomePage "recent" }}
-        {{ range $posts.ByDate.Reverse | first 4 }}
+        {{ range $posts.ByDate.Reverse | first (or .Site.Params.NumberPostsOnHomePage 4) }}
             {{- partial "list-posts.html" . -}}
         {{ end }}
     {{ end }}


### PR DESCRIPTION
I've added simple customization for number of posts on homepage.

Also I've added Polish translation and I've fixed translation for "Recent Posts/Posts" header on homepage. This modification is backward compatible, but one can replace translation to replace "Posts" (for `popular` posts) with "Popular posts" or anything one want.