### PR TITLE
feat(archetypes): add default front matter

### DIFF
--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -1,8 +1,10 @@
 ---
 date: {{ now.Format "2006-01-02" }}
+# description: ""
 # image: ""
 lastmod: {{ now.Format "2006-01-02" }}
 showTableOfContents: false
+# tags: ["",]
 title: "{{ replace .File.ContentBaseName `-` ` ` | title }}"
-type: "page"
+type: "post"
 ---

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -96,7 +96,7 @@ enableRobotsTXT = true
 Here is the way to create your first post:
 
 ```bash
-hugo new posts/first_post.md
+hugo new "content/posts/My First Post.md"
 ```
 
 Feel free to edit the post file by adding some sample content and replacing the title value in the beginning of the file.
@@ -105,6 +105,15 @@ For posts you need to add `type: "post"` in the markdown metadata. We currently 
 
 1. Post (`type: "post"`): A normal blog-post with tags, date, & content.
 2. Page (`type: "page"`): A standalone content page that will just render the markdown you wrote. You can use it to write custom pages which should not be a part of posts. Like showing your projects portfolio. You can read in detail about this on the [Theme Documentation - Advanced](/posts/theme-documentation-advanced/#content-types) page.
+
+#### Using archetypes
+
+`hugo new` will automatically use an appropriate [archetype](https://gohugo.io/content-management/archetypes/) (see [`archetypes/`](https://github.com/526avijitgupta/gokarna/tree/main/archetypes)) and insert [front matter](https://gohugo.io/content-management/front-matter/) depending on the location of your content:
+
+- `hugo new content/posts/$PostName.md` uses `archetypes/posts.md`, and automatically sets `type: "post"`
+- `hugo new content/$PageName.md` uses `archetypes/default.md`, and automatically sets `type: "page"`
+
+Gokarna employs [custom front matter](https://gokarna-hugo.netlify.app/posts/theme-documentation-advanced/#content-types), which is included in the archetypes. The creation date of the content is included in the front matter, and the Markdown filename is used as the default title.
 
 ### e. Launching the Website Locally
 


### PR DESCRIPTION
Implement some basic [Hugo front matter](https://gohugo.io/content-management/front-matter/#fields), and [custom Gokarna front matter](https://gokarna-hugo.netlify.app/posts/theme-documentation-advanced/#content-types), to make life more convenient for [`hugo new` users](https://gokarna-hugo.netlify.app/posts/theme-documentation-basics/#d-create-your-first-post).

Following [Hugo's lookup order](https://gohugo.io/content-management/archetypes/#lookup-order):

- `default.md` applies to `content/`
- `posts.md` applies to `content/posts/`

N.B. Archetypes follow the YAML syntax already laid out in the docs.

## Composition and behaviour

- `lastmod` is *not* rendered when its value is equal to `date`
- `lastmod` is present in `default.md` as the year affects the `footerText` Scratch

## To do

- [x] docs
- [x] screenshots
- tests
  - [x] `.Site.Params.dateFormat`
    Expected behaviour. When `lastmod` > `date`, [`dateFormat`](http://localhost:1313/posts/theme-documentation-basics/#date-format) *must* be configured. This is already true for [Site-wide copyright notice](http://localhost:1313/posts/theme-documentation-advanced/#site-wide-copyright-notice).
  - [x] `showTableOfContents`
    Impartial to `config.toml`'s state when `false`.

---

## Example output

```sh
hugo new "posts/My First Post.md" && hugo new "Here Be Dragons.md"

cat content/posts/My\ First\ Post.md content/Here\ Be\ Dragons.md 

---
date: 2024-10-01
# description: ""
# image: ""
lastmod: 2024-10-01
showTableOfContents: false
# tags: ["",]
title: "My First Post"
type: "post"
---

---
date: 2024-10-01
# image: ""
lastmod: 2024-10-01
showTableOfContents: false
title: "Here Be Dragons"
type: "page"
---
```

### Screenshots

![image](https://github.com/user-attachments/assets/eb01d3d4-6473-4ff0-9389-6b1102aa5f8f)

![image](https://github.com/user-attachments/assets/47c490f1-6a49-43a3-b3fb-3af4a6255c83)