### PR TITLE
fix: Proper names of keys for translated 'Posts' title on posts' list

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -14,5 +14,5 @@
     other = 'Nächster Eintrag'
 [tags]
     other = 'Tags'
-[Posty]
+[Posts]
     other = 'Einträge'

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -14,5 +14,5 @@
   other = 'Next'
 [tags]
   other = 'Tags'
-[Posty]
+[Posts]
     other = 'Posts'

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -14,5 +14,5 @@
   other = 'Siguiente'
 [tags]
   other = 'Etiquetas'
-[Posty]
+[Posts]
   other = 'Entradas'


### PR DESCRIPTION
In previous pull-request #240 I've put incorrect translation keys in i18n files.