### PR TITLE
Fix: `socialIcons` disappear when ad blockers are enabled.

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -28,12 +28,12 @@ a:hover .feather-moon {
   color: white;
 }
 
-.social-icons-list .social-icon,
-.social-icons-list .social-icon a:visited  {
+.gk-social-icons-list .gk-social-icon,
+.gk-social-icons-list .gk-social-icon a:visited  {
   fill: var(--dark-text-color);
 }
 
-.social-icons-list .social-icon a:hover {
+.gk-social-icons-list .gk-social-icon a:hover {
   fill: var(--accent-color);
 }
 
@@ -87,15 +87,15 @@ pre {
   box-shadow: rgb(33, 38, 45) 0px -1px 0px 0px inset;
 }
 
-.arrow-logo { 
+.arrow-logo {
   background-color: var(--dark-secondary-color);
 }
 
 /* TODO: Check if this is needed or not */
-/* 
+/*
 img,
 video {
   filter: hue-rotate(180deg) contrast(100%) invert(100%);
   -webkit-filter: hue-rotate(180deg) contrast(100%) invert(100%);
-} 
+}
 */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -416,18 +416,18 @@ table td {
   font-size: 2em;
 }
 
-.social-icons {
+.gk-social-icons {
   text-align: center;
 }
 
-.social-icons .social-icons-list {
+.gk-social-icons .gk-social-icons-list {
   display: inline-block;
   list-style-type: none;
   padding: 0;
   text-align: center;
 }
 
-.social-icons-list .social-icon {
+.gk-social-icons-list .gk-social-icon {
   box-sizing: border-box;
   display: inline-block;
   fill: var(--light-text-color);
@@ -436,7 +436,7 @@ table td {
   width: 24px;
 }
 
-.social-icon a svg path {
+.gk-social-icon a svg path {
   transition: fill 0.15s ease;
 }
 
@@ -673,7 +673,7 @@ table td {
 }
 
 .arrow-logo:hover {
-  fill:  var(--accent-color); 
+  fill:  var(--accent-color);
 }
 
 @media screen and (max-width: 600px) {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,10 +16,10 @@
 <div class="flex-break"></div>
 
 {{ if isset .Site.Params "socialicons" }}
-<div class="social-icons">
-    <ul class="social-icons-list">
+<div class="gk-social-icons">
+    <ul class="gk-social-icons-list">
         {{ range .Site.Params.SocialIcons }}
-        <li class="social-icon">
+        <li class="gk-social-icon">
             <a href="{{ .url }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} aria-label="Learn more on {{ .name }}">
                 <img class="svg-inject" src="/svg/icons/{{ .name | lower }}.svg" alt="">
             </a>


### PR DESCRIPTION
As suggested by @jamesericdavidson, I am submitting a PR to fix #238.

The `EasyList – Social Widgets` filter was blocking the `##.social-icons-list` class, preventing social media icons from appearing. To fix this, I have simply renamed all instances of `social-icon` to `gk-social-icon` (`gk` = Gokarna).

With this change, the social media links should now display correctly, even when aggressive ad blockers are enabled.

![screenshot](https://github.com/user-attachments/assets/4919e2dc-1253-4657-a3cb-d5669be0948c)
