### PR TITLE
fix: Relative links for non-root hosting

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -8,7 +8,7 @@
     <ul class="post-tags">
         {{ range $.Site.Taxonomies.tags.ByCount }}
         <li class="post-tag">
-            <a href="/tags/{{ .Name | urlize }}/">
+            <a href="{{ .Page.RelPermalink }}">
                 <div class="tag-name">{{ .Name }}</div>
                 <div class="tag-posts-count">{{ .Count }}</div>
             </a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,7 +21,7 @@
         {{ range .Site.Params.SocialIcons }}
         <li class="social-icon">
             <a href="{{ .url }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} aria-label="Learn more on {{ .name }}">
-                <img class="svg-inject" src="/svg/icons/{{ .name | lower }}.svg" alt="">
+                <img class="svg-inject" src="{{ absURL "svg/icons/" }}{{ .name | lower }}.svg" alt="">
             </a>
         </li>
         {{ end }}


### PR DESCRIPTION
Fix for some links in case of hosting page from non-root path like https://example.com/blog