### PR TITLE
feat(config): minify exampleSite HTML output

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -95,3 +95,6 @@ pygmentsStyle = "monokai"
     startLevel = 1
     endLevel = 4
     ordered = false
+
+[minify]
+    minifyOutput = true

--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -367,3 +367,12 @@ Will produce this footer:
 `copyright` can include [Markdown syntax](https://www.markdownguide.org/tools/hugo/). This is best used for including hyperlinks, emoji, or text formatting.
 
 The years of `.Date` and `.Lastmod` are used to create a date range for your copyrighted material. [dateFormat](/posts/theme-documentation-basics/#date-format) **must** be set in `config.toml` if `.Lastmod` is present in any front matter.
+
+## Minification
+
+`hugo`'s HTML output can be [minified](https://gohugo.io/hugo-pipes/minification/#usage), resulting in smaller files. This makes your site more performant (especially when paired with compression), and may confer a better [Google Lighthouse](https://pagespeed.web.dev/) score.
+
+```toml
+[minify]
+    minifyOutput = true
+```


### PR DESCRIPTION
Reduce exampleSite's HTML file size:

![image](https://github.com/user-attachments/assets/5aa04d49-9992-4783-a066-dc9b2e13b8b1)

- Home page reduced by ~3.1k
- Emoji Support reduced by ~67k

- [x] advanced docs

N.B. [The hosted version of `exampleSite`](https://gokarna-hugo.netlify.app/) is not minified:

![image](https://github.com/user-attachments/assets/88a9e6b1-f0d0-425c-9bae-47b9d67b2708)
