### PR TITLE
Use relUrl for SVG injection

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,7 +21,7 @@
         {{ range .Site.Params.SocialIcons }}
         <li class="gk-social-icon">
             <a href="{{ .url }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} aria-label="Learn more on {{ .name }}">
-                <img class="svg-inject" src="{{ absURL "svg/icons/" }}{{ .name | lower }}.svg" alt="">
+                <img class="svg-inject" src="{{ relURL "svg/icons/" }}{{ .name | lower }}.svg" alt="">
             </a>
         </li>
         {{ end }}


### PR DESCRIPTION
This resolves #255, and builds on #249. #249 fixed non-root hosting (#237), but broke alternate-domain hosting. I believe moving from `absUrl` to `relUrl` solves both issues (including making sure the social icons work on the Netlify deploy previews for this repo!).

Would appreciate review from @pkierski as author of #249.